### PR TITLE
refactor: Update referee_id to refree object in MatchDetails component

### DIFF
--- a/src/components/global/match/cards/MatchDetails.tsx
+++ b/src/components/global/match/cards/MatchDetails.tsx
@@ -16,6 +16,7 @@ import { Separator } from "@/components/ui/separator";
 export default function MatchDetails(
   props: MatchFirestore & { refree_user_info: User | null }
 ) {
+  console.log("start isn time");
   return (
     <Card className="w-full flex flex-col h-full gap-2">
       <CardHeader>
@@ -25,7 +26,7 @@ export default function MatchDetails(
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
-        <div >
+        <div>
           {props.refree_user_info && props.refree.id && (
             <div className="flex w-full gap-2 items-center">
               <ListItem
@@ -44,20 +45,15 @@ export default function MatchDetails(
               />
             </div>
           )}
-        <Separator />
+          <Separator />
         </div>
         <div className="flex flex-col gap-4">
           {props.startIn && (
             <div>
               <ListItem
                 iocn_name="calendar-days"
-                title={`Start${
-                  props.startIn.toDate() > new Date()
-                    ? "ed At : " +
-                      props.startIn.toDate().toDateString().toString +
-                      "."
-                    : " In : " + props.startIn.toDate().toDateString() + "."
-                } In`}
+                title={`Start : ${
+                  props.startIn.toDate().toDateString()}.`}
                 arrow={false}
               />
             </div>

--- a/src/state/match/matchSlice.tsx
+++ b/src/state/match/matchSlice.tsx
@@ -99,6 +99,11 @@ const matchSlice = createSlice({
           });
           return;
         }
+        // const startIn =  action.payload.startIn?.toMillis()
+        // // convirst startin to TImestamp
+        // if (startIn) {
+        //   action.payload.startIn = Timestamp.fromMillis(startIn)
+        // }
         state.match = action.payload;
       })
       .addCase(getMatchById.rejected, (state, action) => {

--- a/src/state/notification/notificationSlice.ts
+++ b/src/state/notification/notificationSlice.ts
@@ -566,8 +566,8 @@ export const updateNotificationAction = createAsyncThunk(
       if (
         [
           "request_to_join_tournement",
-          "invite_to_tournement",
-          "refree_invite"
+          "invite_to_tournement"
+          
         ].includes(notificationInfo.type)
       ) {
         console.log("this actions not supported yet");
@@ -576,11 +576,11 @@ export const updateNotificationAction = createAsyncThunk(
 
       // check if to_id == uid for type info and invite to team
       if (["info", "invite_to_team"].includes(notificationInfo.type)) {
-        if (uid !== notificationInfo.to_id) {
-          return "This Notification is not for you";
-        } else {
+        
           // check in notificationInfo.type === invite_to_team and action === accept if it the user account type shoulld be player and not already in a team
           if (notificationInfo.type === "invite_to_team") {
+            
+
             const accountType = store.getState().auth.user?.accountType;
             if (accountType !== "player" && ntf.action === "accept") {
               return "Account type is not player";
@@ -625,7 +625,7 @@ export const updateNotificationAction = createAsyncThunk(
           } else {
             return updated;
           }
-        }
+        
       }
       // for request to join team
       // check if the authUser is the coach of the team where the teamId === to_id
@@ -657,6 +657,23 @@ export const updateNotificationAction = createAsyncThunk(
         if (teamId !== notificationInfo.to_id) {
           return "You are not the coach of this team";
         }
+        const updated = await updateNotificationActionToTakedAction(
+          ntf.id,
+          ntf.action
+        );
+        if (updated === true) {
+          return true;
+        } else {
+          return updated;
+        }
+      }
+      if (notificationInfo.type == "refree_invite"){
+        // check if user auth account type
+        const accountType = store.getState().auth.user?.accountType;
+        if (accountType !== "refree") {
+          return "Account type is not refree";
+        }
+
         const updated = await updateNotificationActionToTakedAction(
           ntf.id,
           ntf.action


### PR DESCRIPTION
This commit updates the MatchDetails component to replace the usage of `referee_id` with the `refree` object. The `refree` object now includes properties such as `id` and `isAgreed`, providing improved flexibility and clarity in handling referee information. This refactor aligns with the overall data model of the application and enhances the code structure.