### PR TITLE
feat: Add invite_referee_to_tournament notification type

### DIFF
--- a/src/state/notification/notificationSlice.ts
+++ b/src/state/notification/notificationSlice.ts
@@ -641,7 +641,7 @@ export const updateNotificationAction = createAsyncThunk(
       }
 
       if (
-        ["request_to_join_tournement", "invite_to_tournement"].includes(
+        ["request_to_join_tournement", "invite_to_tournement","invite_referee_to_tournament"].includes(
           notificationInfo.type
         )
       ) {

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -106,7 +106,8 @@ type NotificationType = "info"
 | "match_chalenge"
 | "refree_invite"
 | "invite_to_team"
-| "invite_to_tournement";
+| "invite_to_tournement"
+| "invite_referee_to_tournament";
 export interface Notification {
   id: string;
   from_id: string;


### PR DESCRIPTION
This commit adds the "invite_referee_to_tournament" notification type to the notificationSlice.ts file. This allows the application to handle notifications related to inviting referees to tournaments.