### PR TITLE
Feat/tournament

### DIFF
--- a/src/components/global/AccountNavDropdownMenu.tsx
+++ b/src/components/global/AccountNavDropdownMenu.tsx
@@ -28,6 +28,8 @@ import { logout } from "@/state/auth/authSlice";
 import { ChangeAccountType } from "./ChangeAccountType";
 import { useEffect, useState } from "react";
 import { getMemberTeamName } from "@/state/team/teamSlice";
+import { getTournamentManagerTournament } from "@/state/notification/notificationSlice";
+import { Tournament } from "@/types/types";
 
 export function AccountNavDropdownMenu() {
   const authLoading = useSelector((state: RootState) => state.auth.loading);
@@ -37,6 +39,7 @@ export function AccountNavDropdownMenu() {
   const accountType = authUser?.accountType;
   const uid = auth?.uid;
   const [teamName, setTeamName] = useState<string | null>(null);
+  const [tournament, setTournament] = useState<Tournament | null>(null);
 
   useEffect(() => {
     if (uid && (accountType === "coach" || accountType === "player")) {
@@ -46,6 +49,16 @@ export function AccountNavDropdownMenu() {
           return;
         }
         setTeamName(teamName);
+      });
+    } else if (uid && accountType === "tournament_manager") {
+      getTournamentManagerTournament().then((tournament) => {
+        if (!tournament) {
+          console.log("Error getting tournament manager tournament");
+          return;
+        }
+        if (typeof tournament === "object" && tournament !== null) {
+          setTournament(tournament);
+        }
       });
     }
   }, [accountType, uid]);
@@ -87,33 +100,30 @@ export function AccountNavDropdownMenu() {
           </Link>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
-          {teamName && (
-        <DropdownMenuGroup>
+        {teamName && (
+          <DropdownMenuGroup>
             <Link to={`/team/page/${teamName}`}>
               <DropdownMenuItem>
                 <Users className="mr-2 h-4 w-4" />
                 <span>Team {teamName}</span>
               </DropdownMenuItem>
             </Link>
-        </DropdownMenuGroup>
+          </DropdownMenuGroup>
+        )}
 
-          )}
-
-          {authUser?.accountType === "refree" && (
-        <DropdownMenuGroup>
-
+        {authUser?.accountType === "refree" && (
+          <DropdownMenuGroup>
             <Link to={`/referee/matches/1`}>
               <DropdownMenuItem>
                 <Timer className="mr-2 h-4 w-4" />
                 <span>Match</span>
               </DropdownMenuItem>
             </Link>
-        </DropdownMenuGroup>
-          )}
+          </DropdownMenuGroup>
+        )}
 
-          {authUser?.accountType === "coach" && (
-        <DropdownMenuGroup>
-
+        {authUser?.accountType === "coach" && (
+          <DropdownMenuGroup>
             <Link to={"/team/create"}>
               <DropdownMenuItem>
                 <Plus className="mr-2 h-4 w-4" />
@@ -121,8 +131,8 @@ export function AccountNavDropdownMenu() {
                 <DropdownMenuShortcut>⌘+T</DropdownMenuShortcut>
               </DropdownMenuItem>
             </Link>
-        </DropdownMenuGroup>
-          )}
+          </DropdownMenuGroup>
+        )}
 
         {authUser?.accountType === "tournament_manager" && (
           <DropdownMenuGroup>
@@ -133,10 +143,10 @@ export function AccountNavDropdownMenu() {
                 <DropdownMenuShortcut>⌘+T</DropdownMenuShortcut>
               </DropdownMenuItem>
             </Link>
-            <Link to={"/tournament/page/tournameidhere"}>
+            <Link to={`/tournament/page/${tournament?.id}`}>
               <DropdownMenuItem>
-                <FlameKindling  className="mr-2 h-4 w-4" />
-                <span>Tournament</span>
+                <FlameKindling className="mr-2 h-4 w-4" />
+                <span>Tournament ({tournament?.name})</span>
                 <DropdownMenuShortcut>⌘+T</DropdownMenuShortcut>
               </DropdownMenuItem>
             </Link>

--- a/todo_tournament_ilorez.md
+++ b/todo_tournament_ilorez.md
@@ -9,15 +9,16 @@
 - [x] : @Abdo-Nsila : get tournament refreesinfo
 - [x] : @ilorez : request to join tournament for team
 - [x] : @ilorez : invite team
-- [ ] : leave tournament for team (require firebase callback function)
 - [x] : @Abdo-Nsila : kick team
-- [ ] : @ilorez : invite refree to tournament
-- [ ] : @ilorez : leave tournament for refree !(in progress)
+- [x] : @ilorez : invite refree to tournament
 - [x] : @ilorez : get tournament notification for tournament manager redux
 - [x] : @ilorez : add notification to notifiaction aside
 - [x] : @ilorez : link notification actions with redux
 - [x] : @Abdo-Nsila : update tournament info
-- [ ] : change account type logic for tournament_manager
+- [x] : @ilorez : change account type logic for tournament_manager
+- [ ] : leave tournament for refree !(in progress) (require firebase callback function)
+- [ ] : leave tournament for team !(in progress) (require firebase callback function)
+- [ ] : Geat referee matches + link it with UI
 
 status : pending => in progress => finish || failed
 
@@ -29,19 +30,18 @@ status : pending => in progress => finish || failed
   - accept invitation (add refree id to refrees_ids)
 - [x] team:
   - accept invitation (add teamid to particiapants)
-- [ ] leave tournament for team (remove teamid from particiapants)
 - [x] kick team (remove teamid from particiapants)
-- [ ]  change account type logic for tournament_manager
+- [x]  change account type logic for tournament_manager
+- [ ] leave tournament for team (remove teamid from particiapants)
+- [ ] leave tournament for refree (remove refreeid from refrees_ids)
 
 ## Tournamnet firesore rules
-
 - [ ] allow read for all
 - [ ] allow write: if request.auth.uid == resource.data.manager_id
 
 ## Rules For Update
-
 - [ ] Refree can't change account if it was in a tournament
-- [ ] Team can't join team if the member of team under tournament min members
+- [ ] Team can't join tournament if the member of team under tournament min members
 - [ ] only tournament manager can change tournament info
 - [ ] no one can change in tournament info if it was in progress or finished
 


### PR DESCRIPTION
The code changes include adding the functionality to invite referees to tournaments and handle tournament notifications for tournament managers. Referees can now be invited to tournaments and accept or decline the invitation. Tournament managers can receive tournament notifications and view them in the notification aside. Additionally, the code includes updating the changeAccountType logic to prevent account type change for tournament managers with active tournaments. The update tournament page and navigation have also been added, allowing tournament managers to update tournament information and navigate to the tournament page after updating.