### PR TITLE
feat: Update tournament manager card to use username and avatar props

### DIFF
--- a/src/components/global/AccountNavDropdownMenu.tsx
+++ b/src/components/global/AccountNavDropdownMenu.tsx
@@ -164,13 +164,13 @@ export function AccountNavDropdownMenu() {
             <DropdownMenuShortcut>⌘+C</DropdownMenuShortcut>
           </DropdownMenuItem>
         </DropdownMenuGroup>
-        <Link to={"tournament/test"}>
+        <Link to={"/tournament/test"}>
           <DropdownMenuItem>
             <TestTube className="mr-2 h-4 w-4" />
             <span>Test brackets</span>
             <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>
           </DropdownMenuItem>
-          </Link>
+        </Link>
         <DropdownMenuSeparator />
         <Link to="/">
           {authLoading ? (

--- a/src/components/global/tournament/cards/TournementInfoCard.tsx
+++ b/src/components/global/tournament/cards/TournementInfoCard.tsx
@@ -1,107 +1,107 @@
-
 import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardFooter,
-    CardHeader,
-    CardTitle,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import ListItem from "../../ListIteam";
 import { Timestamp } from "firebase/firestore";
 import { Navigation } from "lucide-react";
+import TournementManagerCard from "./TournementManagerCard";
+import { User } from "@/types/types";
 // import TournementManagerCard from "./TournementManagerCard";
 
 interface TournementInfoProps {
-    teams: number | null,
-    refree: number | null,
-    maxparticipant: number | null,
-    create_at: Timestamp | null,
-    bio: string | null,
-    location: string | null,
-    start: Timestamp | null,
-    manager: string | null,
+  teams: number | null;
+  refree: number | null;
+  maxparticipant: number | null;
+  create_at: Timestamp | null;
+  bio: string | null;
+  location: string | null;
+  start: Timestamp | null;
+  manager: User | null;
 }
 
-const TournementInfo: React.FC<TournementInfoProps> = ({ manager, bio, refree, teams, maxparticipant, create_at, start, location }) => {
-    const create = new Timestamp(
-        create_at?.seconds || 0,
-        create_at?.nanoseconds || 0
-    );
-    const start_at = new Timestamp(
-        start?.seconds || 0,
-        start?.nanoseconds || 0
-    );
-    return (
-        <Card className="w-full xl:w-[550px] flex flex-col h-full gap-2">
-            <CardHeader>
-                <CardTitle>Tournement Details</CardTitle>
-                <CardDescription className="text-muted-foreground">
-                    {bio}
-                </CardDescription>
-            </CardHeader>
-            <CardContent className="flex flex-col gap-4">
-                <div className="flex w-full gap-2 items-center">
-                    <ListItem
-                        iocn_name="user-check"
-                        title={"Tournement Manager : "}
-                        arrow={false}
-                    />
-                    {manager}
-                    {/* <TournementManagerCard
-                                member={{
-                                    role: "member",
-                                    team_id: "",
-                                    userInfo: props.refree_user_info,
-                                    uid: props.refree.id,
-                                }}
-                            /> */}
-                </div>
-                <Separator className="my-2" />
-                <ListItem
-                    iocn_name="shield-half"
-                    title={`Number of Teams : ${teams}`}
-                    arrow={false}
-                />
-                <ListItem
-                    iocn_name="users"
-                    title={`Number of Refree : ${refree}`}
-                    arrow={false}
-                />
-                <ListItem
-                    iocn_name="calendar-check-2"
-                    title={`Create at : ${create.toDate().toDateString()}`}
-                    arrow={false}
-                />
-                <ListItem
-                    iocn_name="calendar-check"
-                    title={`Start in : ${start_at.toDate().toDateString()}`}
-                    arrow={false}
-                />
-                <ListItem
-                    iocn_name="maximize"
-                    title={`Max participant : ${maxparticipant}`}
-                    arrow={false}
-                />
-                {location &&
-                    <div className="flex gap-2 w-fit">
-                        <ListItem
-                            iocn_name="map-pin"
-                            title={"Location : "}
-                            arrow={false}
-                        />
-                        <a
-                            href={location}
-                            target="_blank"
-                            className="text-sky-500 flex text-sm"
-                        >
-                            <Navigation /> Open
-                        </a>
-                    </div>
-                }
-                {/* </div> */}
-                {/* <div className="flex flex-col gap-4">
+const TournementInfo: React.FC<TournementInfoProps> = ({
+  manager,
+  bio,
+  refree,
+  teams,
+  maxparticipant,
+  create_at,
+  start,
+  location,
+}) => {
+  const create = new Timestamp(
+    create_at?.seconds || 0,
+    create_at?.nanoseconds || 0
+  );
+  const start_at = new Timestamp(start?.seconds || 0, start?.nanoseconds || 0);
+  return (
+    <Card className="w-full xl:w-[550px] flex flex-col h-full gap-2">
+      <CardHeader>
+        <CardTitle>Tournement Details</CardTitle>
+        <CardDescription className="text-muted-foreground">
+          {bio}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex w-full gap-2 items-center">
+          <ListItem
+            iocn_name="user-check"
+            title={"Tournement Manager : "}
+            arrow={false}
+          />
+          {manager && (
+            <TournementManagerCard
+              avatar={manager.avatar}
+              username={manager.username}
+            />
+          )}
+        </div>
+        <Separator className="my-2" />
+        <ListItem
+          iocn_name="shield-half"
+          title={`Number of Teams : ${teams}`}
+          arrow={false}
+        />
+        <ListItem
+          iocn_name="users"
+          title={`Number of Refree : ${refree}`}
+          arrow={false}
+        />
+        <ListItem
+          iocn_name="calendar-check-2"
+          title={`Create at : ${create.toDate().toDateString()}`}
+          arrow={false}
+        />
+        <ListItem
+          iocn_name="calendar-check"
+          title={`Start in : ${start_at.toDate().toDateString()}`}
+          arrow={false}
+        />
+        <ListItem
+          iocn_name="maximize"
+          title={`Max participant : ${maxparticipant}`}
+          arrow={false}
+        />
+        {location && (
+          <div className="flex gap-2 w-fit">
+            <ListItem iocn_name="map-pin" title={"Location : "} arrow={false} />
+            <a
+              href={location}
+              target="_blank"
+              className="text-sky-500 flex text-sm"
+            >
+              <Navigation /> Open
+            </a>
+          </div>
+        )}
+        {/* </div> */}
+        {/* <div className="flex flex-col gap-4">
                     {props.startIn && (
                         <div>
                             <ListItem
@@ -146,13 +146,12 @@ const TournementInfo: React.FC<TournementInfoProps> = ({ manager, bio, refree, t
                         </div>
                     )}
                 </div> */}
-            </CardContent>
-            <CardFooter>
-                <p>{/* TODO:Location map here */}</p>
-            </CardFooter>
-        </Card>
-    );
-}
-
+      </CardContent>
+      <CardFooter>
+        <p>{/* TODO:Location map here */}</p>
+      </CardFooter>
+    </Card>
+  );
+};
 
 export default TournementInfo;

--- a/src/components/global/tournament/cards/TournementManagerCard.tsx
+++ b/src/components/global/tournament/cards/TournementManagerCard.tsx
@@ -1,11 +1,11 @@
-import { Member } from "@/types/types";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { User } from "lucide-react";
 import { Link } from "react-router-dom";
 
 type TournementManagerCardProps = {
-    member: Member;
+    username: string;
+    avatar: string | undefined;
 };
 
 const TournementManagerCard: React.FC<TournementManagerCardProps> = (props) => {
@@ -17,19 +17,19 @@ const TournementManagerCard: React.FC<TournementManagerCardProps> = (props) => {
                 <div className="flex  items-center gap-2">
                     <Avatar className="w-8 h-8">
                         <AvatarImage
-                            src={props.member.userInfo?.avatar}
-                            alt={props.member.userInfo?.username || " avatar"}
+                            src={props.avatar}
+                            alt={props.username || " avatar"}
                             className="object-cover"
                         />
                         <AvatarFallback>
-                            {props.member.userInfo?.username.charAt(0)}
+                            {props.username.charAt(0)}
                         </AvatarFallback>
                     </Avatar>
-                    <h2>{props.member.userInfo?.username}</h2>
+                    <h2>{props.username}</h2>
                 </div>
             </CardHeader>
             <CardContent className="flex items-center justify-center gap-4 m-0 p-0">
-                <Link to={`/users/profile/${props.member.userInfo?.username}`}>
+                <Link to={`/users/profile/${props.username}`}>
                     <User className="mr-2 h-4 w-4" />
                 </Link>
             </CardContent>

--- a/src/pages/tournament/Page.tsx
+++ b/src/pages/tournament/Page.tsx
@@ -19,6 +19,9 @@ export const TournamentPage = () => {
   const tournament = useSelector(
     (state: RootState) => state.tournament.tournament
   );
+  const managerInfo = useSelector(
+    (state: RootState) => state.tournament.managerInfo
+  );
   const participantsTeams = useSelector(
     (state: RootState) => state.tournament.teamsInfo
   );
@@ -87,7 +90,7 @@ export const TournamentPage = () => {
         bio={tournament.description}
         start={tournament.start_date}
         location={tournament.location}
-        manager={tournament.manager_id} />
+        manager={managerInfo} />
 
       <TournamentRefereesList referees={referees} />
       <TournamentTeamsList


### PR DESCRIPTION
The code changes in this commit update the `TournementManagerCard` component to use the `username` and `avatar` props instead of the `member` prop. This simplifies the component and improves reusability.