### PR TITLE
feat: Implement tournament manager card using username and avatar props

### DIFF
--- a/todo_tournament.md
+++ b/todo_tournament.md
@@ -1,42 +1,81 @@
 ## redux actions
 
 - [x] : @ilorez : update create tournament form add loading and handle errors
-- [ ] : @ilorez : update create tournament -> navigate to tournament page
-- [ ] : @ilorez : create update tournament page page
+- [x] : @ilorez : update create tournament -> navigate to tournament page
+- [x] : @Abdo-Nsila : create update tournament page page
+- [x] : @ilorez : navigate to tournament page after update
 - [x] : @Abdo-Nsila : get tournament info
 - [x] : @Abdo-Nsila : get tournament teamsinfo
 - [x] : @Abdo-Nsila : get tournament refreesinfo
 - [x] : @ilorez : request to join tournament for team
 - [x] : @ilorez : invite team
-- [ ] : leave tournament for team (require firebase callback function)
 - [x] : @Abdo-Nsila : kick team
-- [ ] : @ilorez : invite refree to tournament
-- [ ] : @ilorez : leave tournament for refree !(in progress)
-- [ ] : @ilorez : get tournament notification for tournament manager redux
-- [ ] : @ilorez : add notification to notifiaction aside
-- [ ] : @ilorez : link notification actions with redux
+- [x] : @ilorez : invite refree to tournament
+- [x] : @ilorez : get tournament notification for tournament manager redux
+- [x] : @ilorez : add notification to notifiaction aside
+- [x] : @ilorez : link notification actions with redux
 - [x] : @Abdo-Nsila : update tournament info
-- [ ] : change account type logic for tournament_manager
-
-status : pending => in progress => finish || failed
+- [x] : @ilorez : change account type logic for tournament_manager
+- [x] : @Wahmane-Hamza : Create referee matches UI
+- [x] : @ilorez : get matches list and link it with UI
+- [ ] : @Abdo-Nsila : filter matches by status
+- [ ] : infinity scroll for matches
+- [ ] : @ilorez : leave tournament for team !(in progress) (require firebase callback function)
+- [ ] : @ilorez : leave tournament for refree !(in progress) (require firebase callback function)
+- [ ] : @ilorez : cancel tournament
+- [ ] : fix UI & repsponsive of tournament page
+      status : pending => in progress => finish || failed
 
 ## Triggers (in pending status)
 
-- [ ] tournament manager:
+- [x] tournament manager:
   - accept request (add teamid to particiapants)
-- [ ] refree:
+- [x] refree:
   - accept invitation (add refree id to refrees_ids)
-- [ ] team:
+- [x] team:
   - accept invitation (add teamid to particiapants)
+- [x] kick team (remove teamid from particiapants)
+- [x] change account type logic for tournament_manager
 - [ ] leave tournament for team (remove teamid from particiapants)
-- [ ] kick team (remove teamid from particiapants)
-- [ ] : change account type logic for tournament_manager
+- [ ] leave tournament for refree (remove refreeid from refrees_ids)
+- [ ] cancel tournament in pending status remove all requests and invitations
+- [ ] set tournament in canceled status
 
 ## Tournamnet firesore rules
 
 - [ ] allow read for all
 - [ ] allow write: if request.auth.uid == resource.data.manager_id
+- [ ] disable write for all in in progress or finished or canceled tournament status
 
 ## Rules For Update
 
-- [ ] Refree can change account if it was in a tournament
+- [x] Refree can't change account if it was in a tournament
+- [x] Team can't join tournament if the member of team under tournament min members
+- [ ] only tournament manager can change tournament info
+- [ ] no one can change in tournament info if it was in progress or finished
+
+## Front end rules should update
+
+- [ ] the only tournament manager can open update page
+- [x] teamName and username should not contain spaces
+
+## Triggers should update
+
+- [x] teamName and username should not contain spaces
+  - [x] update zod validation for create and update 0/3
+  - [x] update redux checks 0/4
+  - [x] update firebase functions 0/4
+- [x] make start in === the time when the referee start the match or set in progress
+
+## change account type for tournament_manager
+
+- [x] update redux
+- [x] update callback function
+- [x] update referee redux
+- [x] update referee callback function
+
+## Important
+
+- [ ] make sure that everything working just in pending status
+- [ ] the only thing can change in in progress status is the match info a details & cancel tournament that can be done by the tournament manager or referee after tournament asigning a match to him
+- [ ] after submitting the match details the referee is the only one can change the match status and result and finish it

--- a/todo_tournament_ilorez.md
+++ b/todo_tournament_ilorez.md
@@ -16,12 +16,15 @@
 - [x] : @ilorez : link notification actions with redux
 - [x] : @Abdo-Nsila : update tournament info
 - [x] : @ilorez : change account type logic for tournament_manager
-- [ ] : leave tournament for refree !(in progress) (require firebase callback function)
-- [ ] : leave tournament for team !(in progress) (require firebase callback function)
 - [x] : @Wahmane-Hamza : Create referee matches UI
 - [x] : @ilorez : get matches list and link it with UI
-
-status : pending => in progress => finish || failed
+- [ ] : @Abdo-Nsila : filter matches by status
+- [ ] : infinity scroll for matches
+- [ ] : @ilorez : leave tournament for team !(in progress) (require firebase callback function)
+- [ ] : @ilorez : leave tournament for refree !(in progress) (require firebase callback function)
+- [ ] : @ilorez : cancel tournament
+- [ ] : fix UI & repsponsive of tournament page
+      status : pending => in progress => finish || failed
 
 ## Triggers (in pending status)
 
@@ -32,39 +35,47 @@ status : pending => in progress => finish || failed
 - [x] team:
   - accept invitation (add teamid to particiapants)
 - [x] kick team (remove teamid from particiapants)
-- [x]  change account type logic for tournament_manager
+- [x] change account type logic for tournament_manager
 - [ ] leave tournament for team (remove teamid from particiapants)
 - [ ] leave tournament for refree (remove refreeid from refrees_ids)
 - [ ] cancel tournament in pending status remove all requests and invitations
 - [ ] set tournament in canceled status
 
 ## Tournamnet firesore rules
+
 - [ ] allow read for all
 - [ ] allow write: if request.auth.uid == resource.data.manager_id
 - [ ] disable write for all in in progress or finished or canceled tournament status
 
 ## Rules For Update
+
 - [x] Refree can't change account if it was in a tournament
 - [x] Team can't join tournament if the member of team under tournament min members
 - [ ] only tournament manager can change tournament info
 - [ ] no one can change in tournament info if it was in progress or finished
 
-
 ## Front end rules should update
+
 - [ ] the only tournament manager can open update page
 - [x] teamName and username should not contain spaces
 
-
 ## Triggers should update
+
 - [x] teamName and username should not contain spaces
   - [x] update zod validation for create and update 0/3
   - [x] update redux checks 0/4
   - [x] update firebase functions 0/4
 - [x] make start in === the time when the referee start the match or set in progress
 
-
 ## change account type for tournament_manager
+
 - [x] update redux
 - [x] update callback function
 - [x] update referee redux
 - [x] update referee callback function
+
+## Important
+
+- [ ] make sure that everything working just in pending status
+- [ ] the only thing can change in in progress status is the match info a details & cancel tournament that can be done by the tournament manager or referee after tournament asigning a match to him
+- [ ] after submitting the match details the referee is the only one can change the match status and result and finish it


### PR DESCRIPTION
The code changes in this commit update the `TournamentManagerCard` component to use the `username` and `avatar` props instead of the `member` prop. This simplifies the component and improves reusability.